### PR TITLE
feat: add {{ $var | fallback }} fallback syntax to interpolation

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -384,6 +384,69 @@ describe('Templating', function () {
       expect(output.undefinedVariables).toEqual([]);
     });
 
+    it('should use the variable when defined and ignore the fallback', function () {
+      const example = "foo {{ $defined | 'x' }}";
+      const output = interpolateString(example, { defined: 'test' });
+      expect(output.result).toEqual('foo test');
+      expect(output.undefinedVariables).toEqual([]);
+    });
+
+    it('should use the fallback when the variable is missing and still warn', function () {
+      const example = 'foo {{ $missing | Attendance }}';
+      const output = interpolateString(example, { other: 'test' });
+      expect(output.result).toEqual('foo Attendance');
+      expect(output.undefinedVariables).toEqual(['missing']);
+    });
+
+    it('should strip a single quote pair from a quoted fallback', function () {
+      const example = "foo {{ $missing | 'total_attendance' }}";
+      const output = interpolateString(example, { other: 'test' });
+      expect(output.result).toEqual('foo total_attendance');
+      expect(output.undefinedVariables).toEqual(['missing']);
+    });
+
+    it('should strip a single double-quote pair from a quoted fallback', function () {
+      const example = 'foo {{ $missing | "total_attendance" }}';
+      const output = interpolateString(example, { other: 'test' });
+      expect(output.result).toEqual('foo total_attendance');
+      expect(output.undefinedVariables).toEqual(['missing']);
+    });
+
+    it('should leave {{ $missing }} unchanged with no fallback (regression guard)', function () {
+      const example = 'foo {{ $missing }}';
+      const output = interpolateString(example, { other: 'test' });
+      expect(output.result).toEqual('foo {{ $missing }}');
+      expect(output.undefinedVariables).toEqual(['missing']);
+    });
+
+    it('should apply a fallback for a missing nested path', function () {
+      const example = "{{ $a.b.c | 'x' }}";
+      const output = interpolateString(example, { a: { b: {} } });
+      expect(output.result).toEqual('x');
+      expect(output.undefinedVariables).toEqual(['a.b.c']);
+    });
+
+    it('should treat an empty fallback as an empty string and still warn', function () {
+      const example = 'foo {{ $missing | }}bar';
+      const output = interpolateString(example, { other: 'test' });
+      expect(output.result).toEqual('foo bar');
+      expect(output.undefinedVariables).toEqual(['missing']);
+    });
+
+    it('should not apply the fallback when the variable resolves to null', function () {
+      const example = "{{ $nullVal | 'fallback' }}";
+      const output = interpolateString(example, { nullVal: null });
+      expect(output.result).toEqual('');
+      expect(output.undefinedVariables).toEqual([]);
+    });
+
+    it('should leave an escaped interpolation with a fallback literal', function () {
+      const example = 'foo \\{{ $x | y }}';
+      const output = interpolateString(example, { x: 'test' });
+      expect(output.result).toEqual('foo \\{{ $x | y }}');
+      expect(output.undefinedVariables).toEqual([]);
+    });
+
     it('should handle very long variable names', function () {
       const example = '{{ $very_long_variable_name_that_exceeds_normal_length_limits }}';
       const output = interpolateString(example, { 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,24 +29,51 @@ export interface InterpolationResult {
   undefinedVariables: string[];
 }
 
+// If `value` begins and ends with the same quote character (' or "), strip that
+// single outer pair; otherwise return it unchanged. Used so a fallback renders the
+// same shape as a defined value (e.g. `| 'total_attendance'` -> total_attendance).
+function stripOneQuotePair(value: string): string {
+  if (
+    value.length >= 2 &&
+    (value[0] === "'" || value[0] === '"') &&
+    value[value.length - 1] === value[0]
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
 export function interpolateString(value: string, variables?: Record<string, any>): InterpolationResult {
   const undefinedVariables: string[] = [];
-  
+
   if (!variables || Object.keys(variables).length === 0) {
     return { result: value, undefinedVariables: [] };
   }
-  
+
   // Handle escaped interpolation by replacing backslashes before processing
   const unescapedValue = value.replace(/\\\{\{/g, '{{ESCAPED_OPEN}}');
 
-  const pattern = /\{\{\s*\$([a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]*|\[[0-9]+\])*)\s*\}\}/g;
-  
-  const result = unescapedValue.replace(pattern, (match, path) => {
+  // Matches {{ $path }} with an optional trailing `| fallback`.
+  // Group 1 = variable path (inner alternation is non-capturing).
+  // Group 2 = raw fallback text (flat literal; cannot contain `}` or nested {{ }}).
+  const pattern = /\{\{\s*\$([a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]*|\[[0-9]+\])*)\s*(?:\|\s*([^}]*?)\s*)?\}\}/g;
+
+  const result = unescapedValue.replace(pattern, (match, path, fallbackRaw) => {
     // Skip if this is our escaped placeholder
     if (path === 'ESCAPED_OPEN') {
       return match;
     }
-    
+
+    // Called when the path cannot be resolved (bad array index, missing key, or a
+    // non-object encountered mid-path). Always flags the variable as undefined
+    // (DECISION 1), then applies the fallback if one was supplied, else leaves the
+    // original text untouched (preserving pre-fallback behavior).
+    const resolveUnresolved = () => {
+      undefinedVariables.push(path);
+      if (fallbackRaw === undefined) return match;
+      return stripOneQuotePair(fallbackRaw);
+    };
+
     // Parse the path to handle both dot notation and array access
     const pathParts: string[] = [];
     let currentPart = '';
@@ -93,19 +120,16 @@ export function interpolateString(value: string, variables?: Record<string, any>
           if (Array.isArray(variableValue) && index >= 0 && index < variableValue.length) {
             variableValue = variableValue[index];
           } else {
-            undefinedVariables.push(path);
-            return match;
+            return resolveUnresolved();
           }
         } else if (part in variableValue) {
           // Object property access
           variableValue = variableValue[part];
         } else {
-          undefinedVariables.push(path);
-          return match;
+          return resolveUnresolved();
         }
       } else {
-        undefinedVariables.push(path);
-        return match;
+        return resolveUnresolved();
       }
     }
     


### PR DESCRIPTION
## What

Extends Evidence's `{{ $var }}` interpolation (in `interpolateString`) to support an optional trailing `| fallback`:

- `{{ $var }}` (no pipe) behaves exactly as before.
- `{{ $var | fallback }}` resolves to the variable when defined, and to the fallback when the path can't be resolved.

This gives authors (and AI agents) graceful behavior instead of a raw `{{ … }}` leaking into the page.

## Regex

```js
const pattern = /\{\{\s*\$([a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]*|\[[0-9]+\])*)\s*(?:\|\s*([^}]*?)\s*)?\}\}/g;
```

- Group 1 = variable path (inner alternation made non-capturing).
- Group 2 = raw fallback text — a **flat literal**; `[^}]*?` stops at the first `}`, so a fallback cannot contain `}` or nested `{{ }}` (by design).

## `stripOneQuotePair`

If the fallback begins and ends with the same quote char (`'` or `"`), one outer pair is stripped; otherwise it passes through unchanged. So `'total_attendance'` → `total_attendance`, `Attendance` → `Attendance` — a fallback renders the same shape as a defined value.

## Decisions

- **DECISION 1 — still warn when a fallback resolves it: YES.** The variable is still pushed to `undefinedVariables` so typos surface (an AI agent recently used a fallback on a nonexistent variable and it failed silently). One-line-flippable.
- **DECISION 2 — variable defined but `null`/`undefined` → returns `""`, fallback NOT applied.** Fallback only fires from the three path-resolution failure branches (bad array index, missing key, non-object mid-path), now unified via `resolveUnresolved()`.
- Empty fallback `{{ $x | }}` → present empty-string fallback: resolves to `""`, still warns.

## Backward-compat

- Plain `{{ $var }}` unchanged.
- Escaping preserved: the `\{{` → `{{ESCAPED_OPEN}}` sentinel dance and the `path === "ESCAPED_OPEN"` guard still work; `\{{ $x | y }}` stays literal.

## Tests

9 new specs (defined-ignores-fallback, missing-uses-fallback + warns, single/double quote strip, no-fallback regression guard, missing nested path, empty fallback, DECISION 2 null, escaped-with-fallback literal). Full suite: **321 specs, 0 failures**; `tsc --noEmit` clean.

## Release

`@hughess/markdoc` bumped `0.0.0-evidence.28` → `.29`. `dist/` is gitignored and rebuilt by `prepublishOnly` (`build && test && marktest`), so `npm publish` ships fresh compiled output. Evidence mirrors this grammar byte-for-byte and will bump its dep to `^0.0.0-evidence.29` once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)